### PR TITLE
Add staff reminder Discord bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+bot.db
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Staff Reminder Bot
+
+Discord bot that DMs staff members a configurable reminder message. Built with `discord.py` 2.x and slash commands only.
+
+## Features
+- Per‑guild configuration stored in SQLite
+- Rate limited DM sending (2s per DM) with retry on 429
+- `/staff` commands for admins or manager role to manage reminders
+- Optional cron scheduling using APScheduler
+
+## Setup
+1. **Python 3.11+** recommended.
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Create a `.env` file:
+   ```env
+   TOKEN=your_bot_token
+   MANAGER_ROLE_ID=1234567890
+   ```
+4. Enable **Guild Members Intent** in the [Discord developer portal](https://discord.com/developers/applications) for your bot.
+5. Invite the bot using a URL with `bot` and `applications.commands` scopes. Example:
+   ```
+   https://discord.com/oauth2/authorize?client_id=YOUR_CLIENT_ID&scope=bot%20applications.commands&permissions=274877908992
+   ```
+   The permission integer grants the bot ability to read members and send DMs; adjust as needed.
+6. Run the bot:
+   ```bash
+   python main.py
+   ```
+
+## Testing
+Unit tests use `pytest`:
+```bash
+pytest
+```
+
+## Commands
+All commands are under `/staff`:
+- `/staff setrole <role>` – set staff role
+- `/staff setmessage <text>` – set DM message (supports `{guild}`, `{user}`, `{now_iso}`)
+- `/staff remind now` – send reminders immediately
+- `/staff status` – show current configuration
+- `/staff test` – DM caller preview
+- `/staff schedule set <cron>` – schedule daily reminders
+- `/staff schedule clear` – remove schedule
+
+Only Administrators or members with the manager role (from `.env`) may use the management commands.

--- a/config.py
+++ b/config.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseSettings
+
+DEFAULT_MESSAGE = "Please review mod queue and tickets."
+
+
+class EnvConfig(BaseSettings):
+    """Environment configuration loaded from .env."""
+
+    token: str
+    manager_role_id: int
+
+    class Config:
+        env_file = ".env"
+
+
+@dataclass
+class GuildConfig:
+    guild_id: int
+    staff_role_id: Optional[int] = None
+    reminder_message: str = DEFAULT_MESSAGE
+    schedule_cron: Optional[str] = None
+    last_sent_at: Optional[str] = None  # ISO timestamp
+
+
+def render_message(template: str, guild: str, user: str) -> str:
+    """Render placeholders for guild, user and current ISO time."""
+    now_iso = datetime.utcnow().isoformat()
+    return template.format(guild=guild, user=user, now_iso=now_iso)

--- a/db.py
+++ b/db.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import Optional
+
+import aiosqlite
+
+from config import GuildConfig, DEFAULT_MESSAGE
+
+
+class Database:
+    def __init__(self, path: str = "bot.db") -> None:
+        self.path = path
+        self.conn: Optional[aiosqlite.Connection] = None
+
+    async def connect(self) -> None:
+        self.conn = await aiosqlite.connect(self.path)
+        await self.conn.execute(
+            """CREATE TABLE IF NOT EXISTS guild_config(
+            guild_id INTEGER PRIMARY KEY,
+            staff_role_id INTEGER,
+            reminder_message TEXT,
+            schedule_cron TEXT,
+            last_sent_at TEXT
+        )"""
+        )
+        await self.conn.execute(
+            """CREATE TABLE IF NOT EXISTS send_log(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            guild_id INTEGER,
+            user_id INTEGER,
+            status TEXT CHECK(status IN ('sent','failed')),
+            error TEXT,
+            sent_at TEXT
+        )"""
+        )
+        await self.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_send_log_guild_status ON send_log(guild_id, status)"
+        )
+        await self.conn.commit()
+
+    async def close(self) -> None:
+        if self.conn:
+            await self.conn.close()
+
+    async def get_guild_config(self, guild_id: int) -> GuildConfig:
+        assert self.conn is not None
+        async with self.conn.execute(
+            "SELECT staff_role_id, reminder_message, schedule_cron, last_sent_at FROM guild_config WHERE guild_id=?",
+            (guild_id,),
+        ) as cur:
+            row = await cur.fetchone()
+        if row:
+            return GuildConfig(
+                guild_id=guild_id,
+                staff_role_id=row[0],
+                reminder_message=row[1] or DEFAULT_MESSAGE,
+                schedule_cron=row[2],
+                last_sent_at=row[3],
+            )
+        cfg = GuildConfig(guild_id=guild_id)
+        await self.upsert_guild_config(cfg)
+        return cfg
+
+    async def upsert_guild_config(self, cfg: GuildConfig) -> None:
+        assert self.conn is not None
+        await self.conn.execute(
+            """INSERT INTO guild_config(guild_id, staff_role_id, reminder_message, schedule_cron, last_sent_at)
+            VALUES(?,?,?,?,?)
+            ON CONFLICT(guild_id) DO UPDATE SET
+                staff_role_id=excluded.staff_role_id,
+                reminder_message=excluded.reminder_message,
+                schedule_cron=excluded.schedule_cron,
+                last_sent_at=excluded.last_sent_at
+            """,
+            (
+                cfg.guild_id,
+                cfg.staff_role_id,
+                cfg.reminder_message,
+                cfg.schedule_cron,
+                cfg.last_sent_at,
+            ),
+        )
+        await self.conn.commit()
+
+    async def update_guild_config(self, guild_id: int, **fields) -> GuildConfig:
+        cfg = await self.get_guild_config(guild_id)
+        for k, v in fields.items():
+            setattr(cfg, k, v)
+        await self.upsert_guild_config(cfg)
+        return cfg
+
+    async def log_send(self, guild_id: int, user_id: int, status: str, error: Optional[str]) -> None:
+        assert self.conn is not None
+        await self.conn.execute(
+            "INSERT INTO send_log(guild_id, user_id, status, error, sent_at) VALUES (?,?,?,?,datetime('now'))",
+            (guild_id, user_id, status, error),
+        )
+        await self.conn.commit()

--- a/dm_queue.py
+++ b/dm_queue.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Callable, Iterable, Tuple
+
+import discord
+
+from config import GuildConfig, render_message
+from embeds import build_reminder_embed
+
+
+class RateLimiter:
+    def __init__(self, min_interval: float, time_func: Callable[[], float] = time.monotonic) -> None:
+        self.min_interval = min_interval
+        self.time_func = time_func
+        self._last: float | None = None
+
+    async def wait(self) -> None:
+        now = self.time_func()
+        if self._last is not None:
+            delta = now - self._last
+            if delta < self.min_interval:
+                await asyncio.sleep(self.min_interval - delta)
+        self._last = self.time_func()
+
+
+class DMQueue:
+    def __init__(self, db, rate_limiter: RateLimiter | None = None) -> None:
+        self.db = db
+        self.rate_limiter = rate_limiter or RateLimiter(2.0)
+
+    async def send(self, guild: discord.Guild, cfg: GuildConfig) -> Tuple[int, int, int, float]:
+        role = guild.get_role(cfg.staff_role_id) if cfg.staff_role_id else None
+        if not role:
+            return 0, 0, 0, 0.0
+        members = [m for m in role.members if not m.bot]
+        total = len(members)
+        sent = failed = 0
+        for member in members:
+            await self.rate_limiter.wait()
+            msg = render_message(cfg.reminder_message, guild.name, member.display_name)
+            embed = build_reminder_embed(guild.name, msg)
+            try:
+                await member.send(embed=embed)
+                await self.db.log_send(guild.id, member.id, "sent", None)
+                sent += 1
+            except discord.HTTPException as e:
+                if e.status == 429 and getattr(e, "retry_after", None):
+                    await asyncio.sleep(e.retry_after)
+                    try:
+                        await member.send(embed=embed)
+                        await self.db.log_send(guild.id, member.id, "sent", None)
+                        sent += 1
+                        continue
+                    except Exception as e2:  # fall through to failure
+                        err = str(e2)
+                else:
+                    err = str(e)
+                failed += 1
+                await self.db.log_send(guild.id, member.id, "failed", err)
+            except Exception as e:
+                failed += 1
+                await self.db.log_send(guild.id, member.id, "failed", str(e))
+        eta = total * self.rate_limiter.min_interval
+        return total, sent, failed, eta

--- a/embeds.py
+++ b/embeds.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import discord
+
+from config import GuildConfig
+
+
+def build_reminder_embed(guild_name: str, message: str) -> discord.Embed:
+    embed = discord.Embed(
+        title="Staff Reminder",
+        description=message,
+        timestamp=datetime.utcnow(),
+    )
+    embed.set_footer(text=guild_name)
+    return embed
+
+
+def build_status_embed(cfg: GuildConfig, guild: discord.Guild, queued: int) -> discord.Embed:
+    role = guild.get_role(cfg.staff_role_id) if cfg.staff_role_id else None
+    desc = [
+        f"**Staff role:** {role.mention if role else 'not set'}",
+        f"**Message:** {cfg.reminder_message[:140]}",
+        f"**Last sent:** {cfg.last_sent_at or 'never'}",
+        f"**Schedule:** {cfg.schedule_cron or 'none'}",
+        f"**Queued:** {queued}",
+    ]
+    return discord.Embed(title="Staff Reminder Status", description="\n".join(desc))
+
+
+def build_summary_embed(total: int, sent: int, failed: int, eta: float) -> discord.Embed:
+    desc = f"Total: {total}\nSent: {sent}\nFailed: {failed}\nEstimated time: {eta:.1f}s"
+    return discord.Embed(title="Reminder Summary", description=desc)

--- a/main.py
+++ b/main.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from config import EnvConfig
+from db import Database
+from dm_queue import DMQueue
+from embeds import build_reminder_embed, build_status_embed, build_summary_embed
+from scheduler import Scheduler
+
+intents = discord.Intents.none()
+intents.guilds = True
+intents.members = True
+
+
+class StaffBot(commands.Bot):
+    def __init__(self, config: EnvConfig) -> None:
+        super().__init__(command_prefix="!", intents=intents)
+        self.config = config
+        self.db = Database()
+        self.dm_queue = DMQueue(self.db)
+        self.scheduler = Scheduler(self, self.db, self.dm_queue)
+
+    async def setup_hook(self) -> None:
+        await self.db.connect()
+        self.scheduler.start()
+        for guild in self.guilds:
+            cfg = await self.db.get_guild_config(guild.id)
+            if cfg.schedule_cron:
+                self.scheduler.schedule_guild(guild.id, cfg)
+        await self.tree.sync()
+
+    async def on_ready(self) -> None:
+        print(f"Logged in as {self.user} ({self.user.id})")
+
+    async def on_guild_join(self, guild: discord.Guild) -> None:
+        await self.db.get_guild_config(guild.id)
+
+    async def on_guild_remove(self, guild: discord.Guild) -> None:
+        self.scheduler.cancel_guild(guild.id)
+
+
+bot_config = EnvConfig()
+bot = StaffBot(bot_config)
+
+
+def manager_only():
+    async def predicate(inter: discord.Interaction) -> bool:
+        if inter.user.guild_permissions.administrator:
+            return True
+        role = inter.guild.get_role(bot_config.manager_role_id)
+        if role and role in inter.user.roles:
+            return True
+        raise app_commands.CheckFailure("Not authorized")
+
+    return app_commands.check(predicate)
+
+
+staff_group = app_commands.Group(name="staff", description="Staff reminders")
+
+
+@staff_group.command(name="setrole", description="Set staff role")
+@manager_only()
+async def setrole(inter: discord.Interaction, role: discord.Role) -> None:
+    cfg = await bot.db.update_guild_config(inter.guild.id, staff_role_id=role.id)
+    queued = len([m for m in role.members if not m.bot])
+    embed = build_status_embed(cfg, inter.guild, queued)
+    await inter.response.send_message(embed=embed, ephemeral=True)
+
+
+@staff_group.command(name="setmessage", description="Set reminder message")
+@manager_only()
+async def setmessage(inter: discord.Interaction, text: str) -> None:
+    message = text.replace("\\n", "\n")
+    cfg = await bot.db.update_guild_config(inter.guild.id, reminder_message=message)
+    role = inter.guild.get_role(cfg.staff_role_id) if cfg.staff_role_id else None
+    queued = len([m for m in role.members if not m.bot]) if role else 0
+    embed = build_status_embed(cfg, inter.guild, queued)
+    await inter.response.send_message(embed=embed, ephemeral=True)
+
+
+remind_group = app_commands.Group(name="remind", description="Reminder actions")
+
+
+@remind_group.command(name="now", description="Send reminders now")
+@manager_only()
+async def remind_now(inter: discord.Interaction) -> None:
+    cfg = await bot.db.get_guild_config(inter.guild.id)
+    total, sent, failed, eta = await bot.dm_queue.send(inter.guild, cfg)
+    await bot.db.update_guild_config(inter.guild.id, last_sent_at=datetime.utcnow().isoformat())
+    embed = build_summary_embed(total, sent, failed, eta)
+    await inter.response.send_message(embed=embed, ephemeral=True)
+
+
+@staff_group.command(name="status", description="Show current status")
+async def status(inter: discord.Interaction) -> None:
+    cfg = await bot.db.get_guild_config(inter.guild.id)
+    role = inter.guild.get_role(cfg.staff_role_id) if cfg.staff_role_id else None
+    queued = len([m for m in role.members if not m.bot]) if role else 0
+    embed = build_status_embed(cfg, inter.guild, queued)
+    await inter.response.send_message(embed=embed, ephemeral=True)
+
+
+@staff_group.command(name="test", description="DM yourself a reminder")
+async def test(inter: discord.Interaction) -> None:
+    cfg = await bot.db.get_guild_config(inter.guild.id)
+    message = cfg.reminder_message.replace("\\n", "\n")
+    embed = build_reminder_embed(inter.guild.name, message)
+    await inter.user.send(embed=embed)
+    await inter.response.send_message(embed=discord.Embed(description="Sent"), ephemeral=True)
+
+
+schedule_group = app_commands.Group(name="schedule", description="Scheduling")
+
+
+@schedule_group.command(name="set", description="Set schedule")
+@manager_only()
+async def schedule_set(inter: discord.Interaction, cron: str) -> None:
+    cfg = await bot.db.update_guild_config(inter.guild.id, schedule_cron=cron)
+    bot.scheduler.schedule_guild(inter.guild.id, cfg)
+    await inter.response.send_message(embed=discord.Embed(description="Scheduled"), ephemeral=True)
+
+
+@schedule_group.command(name="clear", description="Clear schedule")
+@manager_only()
+async def schedule_clear(inter: discord.Interaction) -> None:
+    await bot.db.update_guild_config(inter.guild.id, schedule_cron=None)
+    bot.scheduler.cancel_guild(inter.guild.id)
+    await inter.response.send_message(embed=discord.Embed(description="Cleared"), ephemeral=True)
+
+staff_group.add_command(remind_group)
+staff_group.add_command(schedule_group)
+bot.tree.add_command(staff_group)
+
+
+@bot.tree.error
+async def on_app_command_error(inter: discord.Interaction, error: app_commands.AppCommandError):
+    if isinstance(error, app_commands.CheckFailure):
+        if inter.response.is_done():
+            await inter.followup.send(embed=discord.Embed(description="Not authorized"), ephemeral=True)
+        else:
+            await inter.response.send_message(embed=discord.Embed(description="Not authorized"), ephemeral=True)
+    else:
+        raise error
+
+
+if __name__ == "__main__":
+    bot.run(bot_config.token)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+discord.py>=2.3
+aiosqlite
+pydantic
+apscheduler
+pytest

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from config import GuildConfig
+
+
+class Scheduler:
+    def __init__(self, bot, db, dm_queue) -> None:
+        self.bot = bot
+        self.db = db
+        self.dm_queue = dm_queue
+        self.scheduler = AsyncIOScheduler()
+        self.jobs: Dict[int, str] = {}
+
+    def start(self) -> None:
+        self.scheduler.start()
+
+    def schedule_guild(self, guild_id: int, cfg: GuildConfig) -> None:
+        if not cfg.schedule_cron:
+            return
+        self.cancel_guild(guild_id)
+        trigger = CronTrigger.from_crontab(cfg.schedule_cron)
+        job = self.scheduler.add_job(self._run_job, trigger, args=[guild_id])
+        self.jobs[guild_id] = job.id
+
+    def cancel_guild(self, guild_id: int) -> None:
+        job_id = self.jobs.pop(guild_id, None)
+        if job_id:
+            self.scheduler.remove_job(job_id)
+
+    async def _run_job(self, guild_id: int) -> None:
+        guild = self.bot.get_guild(guild_id)
+        if guild is None:
+            return
+        cfg = await self.db.get_guild_config(guild_id)
+        await self.dm_queue.send(guild, cfg)
+        await self.db.update_guild_config(guild_id, last_sent_at=datetime.utcnow().isoformat())

--- a/tests/test_placeholders.py
+++ b/tests/test_placeholders.py
@@ -1,0 +1,8 @@
+from config import render_message
+
+
+def test_render_message_replaces_placeholders():
+    msg = render_message("Hi {user} from {guild} at {now_iso}", "Guild", "User")
+    assert "User" in msg
+    assert "Guild" in msg
+    assert "now_iso" not in msg

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,0 +1,30 @@
+import asyncio
+
+from dm_queue import RateLimiter
+
+
+def test_rate_limiter_spacing(monkeypatch):
+    current = 0.0
+
+    def time_func():
+        return current
+
+    sleeps = []
+
+    async def fake_sleep(delay):
+        nonlocal current
+        sleeps.append(delay)
+        current += delay
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    rl = RateLimiter(2.0, time_func)
+
+    async def run():
+        nonlocal current
+        await rl.wait()  # first call, no sleep
+        current += 1.0
+        await rl.wait()  # should sleep 1 second
+
+    asyncio.run(run())
+    assert sleeps == [1.0]


### PR DESCRIPTION
## Summary
- Implement Discord bot to DM staff with configurable message, per-guild SQLite config, and rate-limited queue
- Add scheduling support via APScheduler and slash command management
- Provide placeholder rendering and rate limiter tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68995416d1e08323a7c365ff727d9195