### PR TITLE
Add manager role command and new utility features

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Discord bot that DMs staff members a configurable reminder message. Built with `
    TOKEN=your_bot_token
    MANAGER_ROLE_ID=1234567890
    ```
+   Alternatively, set `HARDCODED_TOKEN` in `main.py` to bypass `.env` usage.
 4. Enable **Guild Members Intent** in the [Discord developer portal](https://discord.com/developers/applications) for your bot.
 5. Invite the bot using a URL with `bot` and `applications.commands` scopes. Example:
    ```
@@ -41,8 +42,18 @@ All commands are under `/staff`:
 - `/staff setrole <role>` – set staff role
 - `/staff setmessage <text>` – set DM message (supports `{guild}`, `{user}`, `{now_iso}`)
 - `/staff remind now` – send reminders immediately
+- `/staff remind user <member>` – DM a specific user
+- `/staff remind channel <channel>` – post reminder in a channel
+- `/staff remind preview` – preview the reminder message
 - `/staff status` – show current configuration
 - `/staff test` – DM caller preview
+- `/staff ping` – show bot latency
+- `/staff setmanager <role>` – set manager role
+- `/staff getmanager` – show manager role
+- `/staff showrole` – show staff role
+- `/staff liststaff` – list staff members
+- `/staff stats` – show reminder statistics
+- `/staff version` – show bot version
 - `/staff schedule set <cron>` – schedule daily reminders
 - `/staff schedule clear` – remove schedule
 

--- a/main.py
+++ b/main.py
@@ -12,6 +12,10 @@ from dm_queue import DMQueue
 from embeds import build_reminder_embed, build_status_embed, build_summary_embed
 from scheduler import Scheduler
 
+# Optionally hardcode the bot token here. If None, token from `.env` is used.
+HARDCODED_TOKEN: str | None = None
+BOT_VERSION = "1.0.0"
+
 intents = discord.Intents.none()
 intents.guilds = True
 intents.members = True
@@ -83,6 +87,68 @@ async def setmessage(inter: discord.Interaction, text: str) -> None:
     await inter.response.send_message(embed=embed, ephemeral=True)
 
 
+@staff_group.command(name="ping", description="Show bot latency")
+async def ping(inter: discord.Interaction) -> None:
+    latency = round(bot.latency * 1000)
+    await inter.response.send_message(f"Pong {latency}ms", ephemeral=True)
+
+
+@staff_group.command(name="setmanager", description="Set manager role")
+@manager_only()
+async def setmanager(inter: discord.Interaction, role: discord.Role) -> None:
+    bot_config.manager_role_id = role.id
+    await inter.response.send_message(
+        f"Manager role set to {role.mention}", ephemeral=True
+    )
+
+
+@staff_group.command(name="getmanager", description="Show manager role")
+async def getmanager(inter: discord.Interaction) -> None:
+    role = inter.guild.get_role(bot_config.manager_role_id)
+    msg = role.mention if role else "No manager role set"
+    await inter.response.send_message(msg, ephemeral=True)
+
+
+@staff_group.command(name="showrole", description="Show staff role")
+async def showrole(inter: discord.Interaction) -> None:
+    cfg = await bot.db.get_guild_config(inter.guild.id)
+    role = inter.guild.get_role(cfg.staff_role_id) if cfg.staff_role_id else None
+    msg = role.mention if role else "No staff role set"
+    await inter.response.send_message(msg, ephemeral=True)
+
+
+@staff_group.command(name="liststaff", description="List staff members")
+async def liststaff(inter: discord.Interaction) -> None:
+    cfg = await bot.db.get_guild_config(inter.guild.id)
+    role = inter.guild.get_role(cfg.staff_role_id) if cfg.staff_role_id else None
+    if not role:
+        await inter.response.send_message("No staff role set", ephemeral=True)
+        return
+    members = [m.mention for m in role.members if not m.bot]
+    text = ", ".join(members) if members else "No staff members found"
+    await inter.response.send_message(text, ephemeral=True)
+
+
+@staff_group.command(name="stats", description="Show reminder statistics")
+async def stats(inter: discord.Interaction) -> None:
+    assert bot.db.conn is not None
+    async with bot.db.conn.execute(
+        "SELECT status, COUNT(*) FROM send_log WHERE guild_id=? GROUP BY status",
+        (inter.guild.id,),
+    ) as cur:
+        rows = await cur.fetchall()
+    data = {status: count for status, count in rows}
+    embed = discord.Embed(title="Send stats")
+    embed.add_field(name="Sent", value=str(data.get("sent", 0)))
+    embed.add_field(name="Failed", value=str(data.get("failed", 0)))
+    await inter.response.send_message(embed=embed, ephemeral=True)
+
+
+@staff_group.command(name="version", description="Show bot version")
+async def version_cmd(inter: discord.Interaction) -> None:
+    await inter.response.send_message(f"Version {BOT_VERSION}", ephemeral=True)
+
+
 remind_group = app_commands.Group(name="remind", description="Reminder actions")
 
 
@@ -93,6 +159,36 @@ async def remind_now(inter: discord.Interaction) -> None:
     total, sent, failed, eta = await bot.dm_queue.send(inter.guild, cfg)
     await bot.db.update_guild_config(inter.guild.id, last_sent_at=datetime.utcnow().isoformat())
     embed = build_summary_embed(total, sent, failed, eta)
+    await inter.response.send_message(embed=embed, ephemeral=True)
+
+
+@remind_group.command(name="user", description="Send reminder to a user")
+@manager_only()
+async def remind_user(inter: discord.Interaction, member: discord.Member) -> None:
+    cfg = await bot.db.get_guild_config(inter.guild.id)
+    message = cfg.reminder_message.replace("\\n", "\n")
+    embed = build_reminder_embed(inter.guild.name, message)
+    await member.send(embed=embed)
+    await inter.response.send_message(embed=discord.Embed(description="Sent"), ephemeral=True)
+
+
+@remind_group.command(name="channel", description="Post reminder in a channel")
+@manager_only()
+async def remind_channel(
+    inter: discord.Interaction, channel: discord.TextChannel
+) -> None:
+    cfg = await bot.db.get_guild_config(inter.guild.id)
+    message = cfg.reminder_message.replace("\\n", "\n")
+    embed = build_reminder_embed(inter.guild.name, message)
+    await channel.send(embed=embed)
+    await inter.response.send_message(embed=discord.Embed(description="Sent"), ephemeral=True)
+
+
+@remind_group.command(name="preview", description="Preview reminder message")
+async def remind_preview(inter: discord.Interaction) -> None:
+    cfg = await bot.db.get_guild_config(inter.guild.id)
+    message = cfg.reminder_message.replace("\\n", "\n")
+    embed = build_reminder_embed(inter.guild.name, message)
     await inter.response.send_message(embed=embed, ephemeral=True)
 
 
@@ -149,4 +245,5 @@ async def on_app_command_error(inter: discord.Interaction, error: app_commands.A
 
 
 if __name__ == "__main__":
-    bot.run(bot_config.token)
+    token = HARDCODED_TOKEN or bot_config.token
+    bot.run(token)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 discord.py>=2.3
 aiosqlite
-pydantic
+pydantic<2
 apscheduler
 pytest


### PR DESCRIPTION
## Summary
- allow optional hardcoded bot token in `main.py`
- add command to set manager role plus several utility commands (ping, list, stats, version, targeted reminders)
- document new commands and token option

## Testing
- `pip install 'pydantic<2'`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_6899566abb3883238ad6c071f2dd7944