### PR TITLE
Handle missing env settings gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Discord bot that DMs staff members a configurable reminder message. Built with `
    ```bash
    pip install -r requirements.txt
    ```
-3. Create a `.env` file:
+3. Create a `.env` file (optional):
    ```env
-   TOKEN=your_bot_token
-   MANAGER_ROLE_ID=1234567890
+   TOKEN=your_bot_token  # optional if `HARDCODED_TOKEN` in `main.py` is set
+   MANAGER_ROLE_ID=1234567890  # optional manager role
    ```
-   Alternatively, set `HARDCODED_TOKEN` in `main.py` to bypass `.env` usage.
+   If you prefer, set `HARDCODED_TOKEN` in `main.py` to bypass `.env` usage.
 4. Enable **Guild Members Intent** in the [Discord developer portal](https://discord.com/developers/applications) for your bot.
 5. Invite the bot using a URL with `bot` and `applications.commands` scopes. Example:
    ```

--- a/config.py
+++ b/config.py
@@ -10,10 +10,14 @@ DEFAULT_MESSAGE = "Please review mod queue and tickets."
 
 
 class EnvConfig(BaseSettings):
-    """Environment configuration loaded from .env."""
+    """Environment configuration loaded from .env.
 
-    token: str
-    manager_role_id: int
+    The values are optional so the bot can start with a hardcoded token or
+    without a manager role configured. Missing values default to ``None``.
+    """
+
+    token: str | None = None
+    manager_role_id: int | None = None
 
     class Config:
         env_file = ".env"

--- a/main.py
+++ b/main.py
@@ -56,7 +56,8 @@ def manager_only():
     async def predicate(inter: discord.Interaction) -> bool:
         if inter.user.guild_permissions.administrator:
             return True
-        role = inter.guild.get_role(bot_config.manager_role_id)
+        role_id = bot_config.manager_role_id
+        role = inter.guild.get_role(role_id) if role_id else None
         if role and role in inter.user.roles:
             return True
         raise app_commands.CheckFailure("Not authorized")
@@ -104,7 +105,8 @@ async def setmanager(inter: discord.Interaction, role: discord.Role) -> None:
 
 @staff_group.command(name="getmanager", description="Show manager role")
 async def getmanager(inter: discord.Interaction) -> None:
-    role = inter.guild.get_role(bot_config.manager_role_id)
+    role_id = bot_config.manager_role_id
+    role = inter.guild.get_role(role_id) if role_id else None
     msg = role.mention if role else "No manager role set"
     await inter.response.send_message(msg, ephemeral=True)
 


### PR DESCRIPTION
## Summary
- Allow EnvConfig to start when token or manager role are absent
- Guard manager-only checks against missing manager role
- Document optional `.env` values

## Testing
- `PYTHONPATH=$PWD pytest`


------
https://chatgpt.com/codex/tasks/task_e_689960fb248c83239c99524a65279c04