### PR TITLE
Send reminders as plain text

### DIFF
--- a/dm_queue.py
+++ b/dm_queue.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import time
-from typing import Callable, Iterable, Tuple
+from typing import Callable, Tuple
 
 import discord
 
 from config import GuildConfig, render_message
-from embeds import build_reminder_embed
 
 
 class RateLimiter:
@@ -40,16 +39,15 @@ class DMQueue:
         for member in members:
             await self.rate_limiter.wait()
             msg = render_message(cfg.reminder_message, guild.name, member.display_name)
-            embed = build_reminder_embed(guild.name, msg)
             try:
-                await member.send(embed=embed)
+                await member.send(msg)
                 await self.db.log_send(guild.id, member.id, "sent", None)
                 sent += 1
             except discord.HTTPException as e:
                 if e.status == 429 and getattr(e, "retry_after", None):
                     await asyncio.sleep(e.retry_after)
                     try:
-                        await member.send(embed=embed)
+                        await member.send(msg)
                         await self.db.log_send(guild.id, member.id, "sent", None)
                         sent += 1
                         continue

--- a/embeds.py
+++ b/embeds.py
@@ -1,21 +1,8 @@
 from __future__ import annotations
 
-from datetime import datetime
-
 import discord
 
 from config import GuildConfig
-
-
-def build_reminder_embed(guild_name: str, message: str) -> discord.Embed:
-    embed = discord.Embed(
-        title="Staff Reminder",
-        description=message,
-        timestamp=datetime.utcnow(),
-    )
-    embed.set_footer(text=guild_name)
-    return embed
-
 
 def build_status_embed(cfg: GuildConfig, guild: discord.Guild, queued: int) -> discord.Embed:
     role = guild.get_role(cfg.staff_role_id) if cfg.staff_role_id else None

--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from discord.ext import commands
 from config import EnvConfig
 from db import Database
 from dm_queue import DMQueue
-from embeds import build_reminder_embed, build_status_embed, build_summary_embed
+from embeds import build_status_embed, build_summary_embed
 from scheduler import Scheduler
 
 # Optionally hardcode the bot token here. If None, token from `.env` is used.
@@ -169,8 +169,7 @@ async def remind_now(inter: discord.Interaction) -> None:
 async def remind_user(inter: discord.Interaction, member: discord.Member) -> None:
     cfg = await bot.db.get_guild_config(inter.guild.id)
     message = cfg.reminder_message.replace("\\n", "\n")
-    embed = build_reminder_embed(inter.guild.name, message)
-    await member.send(embed=embed)
+    await member.send(message)
     await inter.response.send_message(embed=discord.Embed(description="Sent"), ephemeral=True)
 
 
@@ -181,8 +180,7 @@ async def remind_channel(
 ) -> None:
     cfg = await bot.db.get_guild_config(inter.guild.id)
     message = cfg.reminder_message.replace("\\n", "\n")
-    embed = build_reminder_embed(inter.guild.name, message)
-    await channel.send(embed=embed)
+    await channel.send(message)
     await inter.response.send_message(embed=discord.Embed(description="Sent"), ephemeral=True)
 
 
@@ -190,8 +188,7 @@ async def remind_channel(
 async def remind_preview(inter: discord.Interaction) -> None:
     cfg = await bot.db.get_guild_config(inter.guild.id)
     message = cfg.reminder_message.replace("\\n", "\n")
-    embed = build_reminder_embed(inter.guild.name, message)
-    await inter.response.send_message(embed=embed, ephemeral=True)
+    await inter.response.send_message(message, ephemeral=True)
 
 
 @staff_group.command(name="status", description="Show current status")
@@ -207,8 +204,7 @@ async def status(inter: discord.Interaction) -> None:
 async def test(inter: discord.Interaction) -> None:
     cfg = await bot.db.get_guild_config(inter.guild.id)
     message = cfg.reminder_message.replace("\\n", "\n")
-    embed = build_reminder_embed(inter.guild.name, message)
-    await inter.user.send(embed=embed)
+    await inter.user.send(message)
     await inter.response.send_message(embed=discord.Embed(description="Sent"), ephemeral=True)
 
 


### PR DESCRIPTION
## Summary
- remove reminder embed helper and send regular messages
- post and DM reminders without using embeds

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689963ec3f948323afdbc681e8f41d80