### PR TITLE
Handle long interactions and use timezone-aware datetimes

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Optional
 
 from pydantic import BaseSettings
@@ -34,5 +34,5 @@ class GuildConfig:
 
 def render_message(template: str, guild: str, user: str) -> str:
     """Render placeholders for guild, user and current ISO time."""
-    now_iso = datetime.utcnow().isoformat()
+    now_iso = datetime.now(UTC).isoformat()
     return template.format(guild=guild, user=user, now_iso=now_iso)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, UTC
 
 import discord
 from discord import app_commands
@@ -157,11 +157,14 @@ remind_group = app_commands.Group(name="remind", description="Reminder actions")
 @remind_group.command(name="now", description="Send reminders now")
 @manager_only()
 async def remind_now(inter: discord.Interaction) -> None:
+    await inter.response.defer(ephemeral=True)
     cfg = await bot.db.get_guild_config(inter.guild.id)
     total, sent, failed, eta = await bot.dm_queue.send(inter.guild, cfg)
-    await bot.db.update_guild_config(inter.guild.id, last_sent_at=datetime.utcnow().isoformat())
+    await bot.db.update_guild_config(
+        inter.guild.id, last_sent_at=datetime.now(UTC).isoformat()
+    )
     embed = build_summary_embed(total, sent, failed, eta)
-    await inter.response.send_message(embed=embed, ephemeral=True)
+    await inter.followup.send(embed=embed, ephemeral=True)
 
 
 @remind_group.command(name="user", description="Send reminder to a user")

--- a/scheduler.py
+++ b/scheduler.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Dict
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -39,4 +39,6 @@ class Scheduler:
             return
         cfg = await self.db.get_guild_config(guild_id)
         await self.dm_queue.send(guild, cfg)
-        await self.db.update_guild_config(guild_id, last_sent_at=datetime.utcnow().isoformat())
+        await self.db.update_guild_config(
+            guild_id, last_sent_at=datetime.now(UTC).isoformat()
+        )


### PR DESCRIPTION
## Summary
- defer long-running reminder interactions before sending results
- replace deprecated `datetime.utcnow()` with timezone-aware UTC calls

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899745d6dc8832394b091fc62ca5eb3