### PR TITLE
Enable message content intent for bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Discord bot that DMs staff members a configurable reminder message. Built with `
    MANAGER_ROLE_ID=1234567890  # optional manager role
    ```
    If you prefer, set `HARDCODED_TOKEN` in `main.py` to bypass `.env` usage.
-4. Enable **Guild Members Intent** in the [Discord developer portal](https://discord.com/developers/applications) for your bot.
+4. Enable **Guild Members** and **Message Content** intents in the [Discord developer portal](https://discord.com/developers/applications) for your bot.
 5. Invite the bot using a URL with `bot` and `applications.commands` scopes. Example:
    ```
    https://discord.com/oauth2/authorize?client_id=YOUR_CLIENT_ID&scope=bot%20applications.commands&permissions=274877908992

--- a/main.py
+++ b/main.py
@@ -19,6 +19,7 @@ BOT_VERSION = "1.0.0"
 intents = discord.Intents.none()
 intents.guilds = True
 intents.members = True
+intents.message_content = True
 
 
 class StaffBot(commands.Bot):


### PR DESCRIPTION
## Summary
- enable Discord message content intent in bot setup
- document enabling Message Content intent in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68997c26d9f88323be85805510f05220