### PR TITLE
feat: add logging and log channel command

### DIFF
--- a/config.py
+++ b/config.py
@@ -30,6 +30,7 @@ class GuildConfig:
     reminder_message: str = DEFAULT_MESSAGE
     schedule_cron: Optional[str] = None
     last_sent_at: Optional[str] = None  # ISO timestamp
+    log_channel_id: Optional[int] = None
 
 
 def render_message(template: str, guild: str, user: str) -> str:

--- a/dm_queue.py
+++ b/dm_queue.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+import logging
 from typing import Callable, Tuple
 
 import discord
@@ -28,6 +29,21 @@ class DMQueue:
     def __init__(self, db, rate_limiter: RateLimiter | None = None) -> None:
         self.db = db
         self.rate_limiter = rate_limiter or RateLimiter(2.0)
+        self.logger = logging.getLogger(__name__)
+
+    async def log(self, guild: discord.Guild, cfg: GuildConfig, target: str, status: str, message: str, error: str | None = None) -> None:
+        """Log message sending to console and optional log channel."""
+        self.logger.info("%s -> %s: %s", status.upper(), target, message)
+        if cfg.log_channel_id:
+            channel = guild.get_channel(cfg.log_channel_id)
+            if channel:
+                embed = discord.Embed(title="Message Log")
+                embed.add_field(name="Target", value=target, inline=False)
+                embed.add_field(name="Status", value=status, inline=True)
+                if error:
+                    embed.add_field(name="Error", value=error, inline=False)
+                embed.add_field(name="Message", value=message[:1024], inline=False)
+                await channel.send(embed=embed)
 
     async def send(self, guild: discord.Guild, cfg: GuildConfig) -> Tuple[int, int, int, float]:
         role = guild.get_role(cfg.staff_role_id) if cfg.staff_role_id else None
@@ -42,6 +58,7 @@ class DMQueue:
             try:
                 await member.send(msg)
                 await self.db.log_send(guild.id, member.id, "sent", None)
+                await self.log(guild, cfg, f"{member} ({member.id})", "sent", msg)
                 sent += 1
             except discord.HTTPException as e:
                 if e.status == 429 and getattr(e, "retry_after", None):
@@ -49,6 +66,7 @@ class DMQueue:
                     try:
                         await member.send(msg)
                         await self.db.log_send(guild.id, member.id, "sent", None)
+                        await self.log(guild, cfg, f"{member} ({member.id})", "sent", msg)
                         sent += 1
                         continue
                     except Exception as e2:  # fall through to failure
@@ -57,8 +75,11 @@ class DMQueue:
                     err = str(e)
                 failed += 1
                 await self.db.log_send(guild.id, member.id, "failed", err)
+                await self.log(guild, cfg, f"{member} ({member.id})", "failed", msg, err)
             except Exception as e:
                 failed += 1
-                await self.db.log_send(guild.id, member.id, "failed", str(e))
+                err = str(e)
+                await self.db.log_send(guild.id, member.id, "failed", err)
+                await self.log(guild, cfg, f"{member} ({member.id})", "failed", msg, err)
         eta = total * self.rate_limiter.min_interval
         return total, sent, failed, eta

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, UTC
+import logging
 
 import discord
 from discord import app_commands
@@ -21,10 +22,13 @@ intents.guilds = True
 intents.members = True
 intents.message_content = True
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 
 class StaffBot(commands.Bot):
     def __init__(self, config: EnvConfig) -> None:
-        super().__init__(command_prefix="!", intents=intents)
+        super().__init__(command_prefix=",", intents=intents)
         self.config = config
         self.db = Database()
         self.dm_queue = DMQueue(self.db)
@@ -40,7 +44,7 @@ class StaffBot(commands.Bot):
         await self.tree.sync()
 
     async def on_ready(self) -> None:
-        print(f"Logged in as {self.user} ({self.user.id})")
+        logger.info("Logged in as %s (%s)", self.user, self.user.id)
 
     async def on_guild_join(self, guild: discord.Guild) -> None:
         await self.db.get_guild_config(guild.id)
@@ -64,6 +68,33 @@ def manager_only():
         raise app_commands.CheckFailure("Not authorized")
 
     return app_commands.check(predicate)
+
+
+def manager_only_ctx():
+    async def predicate(ctx: commands.Context) -> bool:
+        if ctx.author.guild_permissions.administrator:
+            return True
+        role_id = bot_config.manager_role_id
+        role = ctx.guild.get_role(role_id) if role_id else None
+        if role and role in ctx.author.roles:
+            return True
+        raise commands.CheckFailure("Not authorized")
+
+    return commands.check(predicate)
+
+
+@bot.group(name="staffdm")
+@commands.guild_only()
+async def staffdm_group(ctx: commands.Context) -> None:
+    if ctx.invoked_subcommand is None:
+        await ctx.send(embed=discord.Embed(description="Invalid subcommand"))
+
+
+@staffdm_group.command(name="logchannel")
+@manager_only_ctx()
+async def staffdm_logchannel(ctx: commands.Context, channel: discord.TextChannel) -> None:
+    cfg = await bot.db.update_guild_config(ctx.guild.id, log_channel_id=channel.id)
+    await ctx.send(embed=discord.Embed(description=f"Log channel set to {channel.mention}"))
 
 
 staff_group = app_commands.Group(name="staff", description="Staff reminders")
@@ -174,6 +205,7 @@ async def remind_user(inter: discord.Interaction, member: discord.Member) -> Non
     cfg = await bot.db.get_guild_config(inter.guild.id)
     message = cfg.reminder_message.replace("\\n", "\n")
     await member.send(message)
+    await bot.dm_queue.log(inter.guild, cfg, f"{member} ({member.id})", "sent", message)
     await inter.response.send_message(embed=discord.Embed(description="Sent"), ephemeral=True)
 
 
@@ -185,6 +217,13 @@ async def remind_channel(
     cfg = await bot.db.get_guild_config(inter.guild.id)
     message = cfg.reminder_message.replace("\\n", "\n")
     await channel.send(message)
+    await bot.dm_queue.log(
+        inter.guild,
+        cfg,
+        f"Channel {channel} ({channel.id})",
+        "sent",
+        message,
+    )
     await inter.response.send_message(embed=discord.Embed(description="Sent"), ephemeral=True)
 
 
@@ -209,6 +248,7 @@ async def test(inter: discord.Interaction) -> None:
     cfg = await bot.db.get_guild_config(inter.guild.id)
     message = cfg.reminder_message.replace("\\n", "\n")
     await inter.user.send(message)
+    await bot.dm_queue.log(inter.guild, cfg, f"{inter.user} ({inter.user.id})", "sent", message)
     await inter.response.send_message(embed=discord.Embed(description="Sent"), ephemeral=True)
 
 
@@ -242,6 +282,14 @@ async def on_app_command_error(inter: discord.Interaction, error: app_commands.A
             await inter.followup.send(embed=discord.Embed(description="Not authorized"), ephemeral=True)
         else:
             await inter.response.send_message(embed=discord.Embed(description="Not authorized"), ephemeral=True)
+    else:
+        raise error
+
+
+@bot.event
+async def on_command_error(ctx: commands.Context, error: commands.CommandError):
+    if isinstance(error, commands.CheckFailure):
+        await ctx.send(embed=discord.Embed(description="Not authorized"))
     else:
         raise error
 


### PR DESCRIPTION
## Summary
- add log_channel_id to guild config and database
- log DM sends to console and configurable log channel
- introduce `,staffdm logchannel` prefix command
- define manager-only check before using `,staffdm` subcommand to avoid import error

## Testing
- `python3 -m pip install --break-system-packages discord.py aiosqlite "pydantic<2" apscheduler`
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68999fa511388323bddf31b8f7d388a1