### PR TITLE
Add log channel command and DB migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ pytest
 All commands are under `/staff`:
 - `/staff setrole <role>` – set staff role
 - `/staff setmessage <text>` – set DM message (supports `{guild}`, `{user}`, `{now_iso}`)
+- `/staff setlogchannel <channel>` – set channel where send logs will be posted
 - `/staff remind now` – send reminders immediately
 - `/staff remind user <member>` – DM a specific user
 - `/staff remind channel <channel>` – post reminder in a channel

--- a/db.py
+++ b/db.py
@@ -24,6 +24,12 @@ class Database:
             log_channel_id INTEGER
         )"""
         )
+        async with self.conn.execute("PRAGMA table_info(guild_config)") as cur:
+            cols = [row[1] for row in await cur.fetchall()]
+        if "log_channel_id" not in cols:
+            await self.conn.execute(
+                "ALTER TABLE guild_config ADD COLUMN log_channel_id INTEGER"
+            )
         await self.conn.execute(
             """CREATE TABLE IF NOT EXISTS send_log(
             id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/main.py
+++ b/main.py
@@ -120,6 +120,15 @@ async def setmessage(inter: discord.Interaction, text: str) -> None:
     await inter.response.send_message(embed=embed, ephemeral=True)
 
 
+@staff_group.command(name="setlogchannel", description="Set log channel")
+@manager_only()
+async def setlogchannel(inter: discord.Interaction, channel: discord.TextChannel) -> None:
+    await bot.db.update_guild_config(inter.guild.id, log_channel_id=channel.id)
+    await inter.response.send_message(
+        f"Log channel set to {channel.mention}", ephemeral=True
+    )
+
+
 @staff_group.command(name="ping", description="Show bot latency")
 async def ping(inter: discord.Interaction) -> None:
     latency = round(bot.latency * 1000)

--- a/tests/test_db_migration.py
+++ b/tests/test_db_migration.py
@@ -1,0 +1,36 @@
+import asyncio
+import aiosqlite
+
+from db import Database
+
+
+def test_connect_adds_log_channel(tmp_path):
+    db_path = tmp_path / "test.db"
+
+    async def setup_old_schema():
+        conn = await aiosqlite.connect(db_path)
+        await conn.execute(
+            """CREATE TABLE guild_config(
+            guild_id INTEGER PRIMARY KEY,
+            staff_role_id INTEGER,
+            reminder_message TEXT,
+            schedule_cron TEXT,
+            last_sent_at TEXT
+        )"""
+        )
+        await conn.commit()
+        await conn.close()
+
+    asyncio.run(setup_old_schema())
+
+    db = Database(str(db_path))
+    asyncio.run(db.connect())
+
+    async def fetch_columns():
+        assert db.conn is not None
+        async with db.conn.execute("PRAGMA table_info(guild_config)") as cur:
+            return [row[1] for row in await cur.fetchall()]
+
+    cols = asyncio.run(fetch_columns())
+    assert "log_channel_id" in cols
+    asyncio.run(db.close())


### PR DESCRIPTION
## Summary
- add `/staff setlogchannel` command to configure logging channel
- migrate existing databases to include `log_channel_id` column
- document log channel command and test database migration

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bba2685d48323842f013348da993f